### PR TITLE
Update contact info

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -4,10 +4,12 @@ title: Contact Us
 permalink: /contact/
 ---
 
-AtomVM users and developers can be found on the [AtomVM Forum](https://erlangforums.com/c/erlang-platforms/atomvm-forum/76).
+AtomVM users and developers can be found on the [AtomVM Forum](https://erlangforums.com/atomvm).
 
 We have an active Telegram community dicussing [AtomVM - Erlang and Elixir on Microcontrollers 🏝](https://t.me/atomvm).
-We also hang out on the [AtomVM Discord](https://discord.gg/QA7fNjm9Nw) channel.
+We also hang out on the [AtomVM Discord](https://discord.gg/QA7fNjm9Nw) channel, and occasionally
+in the `#atomvm` channels on the [Erlang](erlanger.slack.com) and [Elixir](elixir-lang.slack.com)
+slack servers.
 
 Drop in and say hello!
 


### PR DESCRIPTION
Updates the link to the AtomVM forum on erlangforums.com with the nicer and more memorable shortcut link. Adds the #atomvm channel on the Elixir and Erlang slack servers.