### PR TITLE
extensions.md: add amqtt_client, remove mjson

### DIFF
--- a/extensions.md
+++ b/extensions.md
@@ -55,7 +55,6 @@ for `atomvm_neopixel`)
 
 ## Libraries
 * [`avm_scene`](https://github.com/atomvm/avm_scene) An OTP display orchestration application
-* [`mjson`](https://github.com/mbj4668/mjson) Purerlang JSON encoder and decoder designed for
-AtomVM
+* [`amqtt_client`](https://github.com/atomvm/amqtt/tree/main/amqtt_client) An MQTT client library optimized for AtomVM
 
 If you have an extension to AtomVM you would like listed here, please [contact](../contact) us.


### PR DESCRIPTION
- Add the newly introduced amqtt_client
- Remove mjson, now AtomVM has support for Erlang/OTP JSON API